### PR TITLE
Fix home page layout and update font to Spectral

### DIFF
--- a/themes/stream/assets/css/main.css
+++ b/themes/stream/assets/css/main.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,600;1,400&display=swap');
+
 * {
     margin: 0;
     padding: 0;
@@ -5,7 +7,7 @@
 }
 
 body {
-    font-family: 'Iowan Old Style', 'Palatino Linotype', 'URW Palladio L', P052, serif;
+    font-family: 'Spectral', serif;
     font-size: 18px;
     line-height: 1.6;
     color: #1a1a1a;

--- a/themes/stream/layouts/index.html
+++ b/themes/stream/layouts/index.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
 <div class="stream">
-    {{ range .Site.RegularPages }}
+    {{ $posts := where .Site.RegularPages "Section" "posts" }}
+    {{ range $posts }}
         {{ if .Title }}
             <!-- Post with title: show title, first paragraph, and read more link -->
             <article class="post titled-post">


### PR DESCRIPTION
- Filter home page to only show posts from posts/ section, excluding About page
- Change font from Iowan Old Style to Spectral (Google Fonts)
- Timestamps already display on home page for all posts