### PR TITLE
Improve cache busting for CSS and JS assets

### DIFF
--- a/themes/stream/assets/css/main.css
+++ b/themes/stream/assets/css/main.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,600;1,400&display=swap');
-
 * {
     margin: 0;
     padding: 0;

--- a/themes/stream/layouts/_partials/head.html
+++ b/themes/stream/layouts/_partials/head.html
@@ -1,5 +1,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>
-{{ partialCached "head/css.html" . }}
-{{ partialCached "head/js.html" . }}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+{{ partial "head/css.html" . }}
+{{ partial "head/js.html" . }}


### PR DESCRIPTION
- Remove partialCached from CSS and JS includes to ensure fresh fingerprinted URLs
- Move Google Fonts import from CSS to HTML head with preconnect for better performance
- Fingerprinting was already enabled but cached partials prevented new hashes from being used