### PR TITLE
Add quote post type for featured quotes in main feed

### DIFF
--- a/archetypes/quote.md
+++ b/archetypes/quote.md
@@ -1,0 +1,7 @@
++++
+date = '{{ .Date }}'
+draft = false
+quote = ''
+author = ''
++++
+

--- a/content/posts/example-quote.md
+++ b/content/posts/example-quote.md
@@ -1,8 +1,0 @@
-+++
-date = '2026-01-29T06:00:00Z'
-draft = false
-quote = 'The best way to predict the future is to invent it.'
-author = 'Alan Kay'
-+++
-
-This quote has always resonated with me when thinking about technology and innovation. It's a reminder that we're not passive observers of the future—we're active participants in creating it.

--- a/content/posts/example-quote.md
+++ b/content/posts/example-quote.md
@@ -1,0 +1,8 @@
++++
+date = '2026-01-29T06:00:00Z'
+draft = false
+quote = 'The best way to predict the future is to invent it.'
+author = 'Alan Kay'
++++
+
+This quote has always resonated with me when thinking about technology and innovation. It's a reminder that we're not passive observers of the future—we're active participants in creating it.

--- a/themes/stream/assets/css/main.css
+++ b/themes/stream/assets/css/main.css
@@ -183,9 +183,7 @@ article.post {
 
 .quote-post .quote-commentary {
     margin-top: 1.25rem;
-    padding-left: 2rem;
-    color: #4a4a4a;
-    font-size: 0.95rem;
+    color: #2a2a2a;
 }
 
 .quote-post .quote-commentary p {

--- a/themes/stream/assets/css/main.css
+++ b/themes/stream/assets/css/main.css
@@ -147,6 +147,51 @@ article.post {
     margin-bottom: 0.75rem;
 }
 
+/* Quote posts */
+.quote-post {
+    position: relative;
+}
+
+.quote-post .quote-block {
+    margin-top: 0.5rem;
+    padding: 1.5rem 2rem;
+    background: #fefefe;
+    border-left: 4px solid #fa8072;
+    border-radius: 4px;
+    font-size: 1.3rem;
+    line-height: 1.5;
+    color: #2a2a2a;
+    font-style: italic;
+}
+
+.quote-post .quote-block p {
+    margin-bottom: 1rem;
+}
+
+.quote-post .quote-block p:last-child {
+    margin-bottom: 0;
+}
+
+.quote-post .quote-block cite {
+    display: block;
+    margin-top: 1rem;
+    font-size: 1rem;
+    font-style: normal;
+    color: #888;
+    font-weight: 500;
+}
+
+.quote-post .quote-commentary {
+    margin-top: 1.25rem;
+    padding-left: 2rem;
+    color: #4a4a4a;
+    font-size: 0.95rem;
+}
+
+.quote-post .quote-commentary p {
+    margin-bottom: 0.75rem;
+}
+
 /* Timestamps */
 time {
     display: block;

--- a/themes/stream/layouts/index.html
+++ b/themes/stream/layouts/index.html
@@ -26,13 +26,31 @@
                 </article>
             {{ end }}
         {{ else }}
-            <!-- Post without title: show inline -->
-            <article class="post inline-post">
-                <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" data-timestamp="{{ .Date.Unix }}"></time>
-                <div class="content">
-                    {{ .Content }}
-                </div>
-            </article>
+            {{ if .Params.quote }}
+                <!-- Quote post: large quote block with optional commentary below -->
+                <article class="post quote-post">
+                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" data-timestamp="{{ .Date.Unix }}"></time>
+                    <blockquote class="quote-block">
+                        {{ .Params.quote | markdownify }}
+                        {{ if .Params.author }}
+                            <cite>— {{ .Params.author }}</cite>
+                        {{ end }}
+                    </blockquote>
+                    {{ if .Content }}
+                        <div class="quote-commentary">
+                            {{ .Content }}
+                        </div>
+                    {{ end }}
+                </article>
+            {{ else }}
+                <!-- Post without title: show inline -->
+                <article class="post inline-post">
+                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" data-timestamp="{{ .Date.Unix }}"></time>
+                    <div class="content">
+                        {{ .Content }}
+                    </div>
+                </article>
+            {{ end }}
         {{ end }}
     {{ end }}
 </div>


### PR DESCRIPTION
- Add quote-post article type to index.html template
- Support for 'quote' and optional 'author' front matter parameters
- Large, prominent quote block styling with salmon accent border
- Optional commentary content below quote
- No title or standalone page - quotes only appear in stream
- Create quote.md archetype for easy quote creation
- Add example quote post demonstrating the feature

Quote posts display with:
- Larger font size (1.3rem) and italic styling
- White background with left border accent
- Author citation if provided
- Optional commentary in smaller, indented text