### PR TITLE
Save Signal editions to dated archive folders

### DIFF
--- a/.github/workflows/signal.yml
+++ b/.github/workflows/signal.yml
@@ -36,6 +36,6 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git add static/signal/index.html
+          git add static/signal/
           git diff --cached --quiet || git commit -m "Update Today's Signal - $(date -u +'%Y-%m-%d %H:%M UTC')"
           git push

--- a/signal/config.yaml
+++ b/signal/config.yaml
@@ -96,6 +96,3 @@ papers_sources:
 briefing:
   enabled: true
 
-# Output
-output:
-  file: "../static/signal/index.html"

--- a/signal/generate.py
+++ b/signal/generate.py
@@ -367,10 +367,13 @@ def generate_html(config, data):
     now = datetime.now()
     if now.hour < 12:
         edition = "Morning Edition"
+        edition_slug = "morning"
     elif now.hour < 18:
         edition = "Afternoon Edition"
+        edition_slug = "afternoon"
     else:
         edition = "Evening Edition"
+        edition_slug = "evening"
 
     html = template.render(
         newspaper_name=config["newspaper_name"],
@@ -391,9 +394,35 @@ def generate_html(config, data):
         briefing=data["briefing"],
     )
 
-    output_path = Path(__file__).parent / config["output"]["file"]
-    output_path.write_text(html)
-    print(f"Generated {output_path}")
+    # Save edition to dated folder: static/signal/YYYY-MM-DD/morning.html
+    date_str = now.strftime("%Y-%m-%d")
+    signal_dir = Path(__file__).parent / "../static/signal"
+    edition_dir = signal_dir / date_str
+    edition_dir.mkdir(parents=True, exist_ok=True)
+
+    edition_path = edition_dir / f"{edition_slug}.html"
+    edition_path.write_text(html)
+    print(f"Generated {edition_path}")
+
+    # Update the index redirect to point to this latest edition
+    edition_url = f"/signal/{date_str}/{edition_slug}.html"
+    redirect_html = f"""<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
+<meta http-equiv="refresh" content="0; url={edition_url}">
+<script>window.location.replace("{edition_url}");</script>
+</head>
+<body>
+<p>Redirecting to <a href="{edition_url}">latest edition</a>...</p>
+</body>
+</html>
+"""
+    index_path = signal_dir / "index.html"
+    index_path.write_text(redirect_html)
+    print(f"Updated redirect at {index_path} → {edition_url}")
 
 
 def main():


### PR DESCRIPTION
## Summary

- Each edition is now saved as `static/signal/YYYY-MM-DD/{morning,afternoon,evening}.html`, giving every edition a unique, permanent URL — this eliminates CDN/browser caching issues entirely
- `static/signal/index.html` is updated on each run to a lightweight redirect page pointing at the latest edition, so `edparry.com/signal` always loads the most recent newspaper
- `git add static/signal/` in the workflow now stages both the new dated files and the updated redirect

## Test plan

- [ ] Manually trigger the `Generate Today's Signal` workflow and confirm a new `static/signal/YYYY-MM-DD/{edition}.html` file is committed
- [ ] Confirm `static/signal/index.html` is updated to redirect to the new file
- [ ] Visit `edparry.com/signal` and confirm it redirects to the correct dated edition
- [ ] Trigger again later in the day (different edition window) and confirm a new file appears alongside the earlier one in the same date folder

https://claude.ai/code/session_01FQEutzKKi72rFLasYMRCt7